### PR TITLE
Use levels from 'enb-bem-techs'

### DIFF
--- a/lib/level-scanner.js
+++ b/lib/level-scanner.js
@@ -1,5 +1,5 @@
 var vow = require('vow'),
-    Level = require('enb/lib/levels/level');
+    Level = require('enb-bem-techs/lib/levels/level');
 
 function getAllLevelFiles(level) {
     var blocks = level.blocks,

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "enb": ">= 0.8.22",
+    "enb-bem-techs": "1.0.0-rc2",
     "jshint": "2.5.10",
     "jscs": "1.8.0",
     "bem-naming": "0.4.0"


### PR DESCRIPTION
Если использовать форк enb, который чинит все для винды, то сборка работает и без использования enb-bem-techs, но мы же вроде бы договорились считать levels в enb как deprecated.
