### PR TITLE
Fix creating of symlinks on Windows OS

### DIFF
--- a/examples/copy-level/.enb/make.js
+++ b/examples/copy-level/.enb/make.js
@@ -15,7 +15,8 @@ module.exports = function (config) {
 
                 return {
                     sourcePath: file.fullname,
-                    targetPath: path.join(dstpath, nestedPath, file.name)
+                    targetPath: path.join(dstpath, nestedPath, file.name),
+                    isDirectory: file.isDirectory
                 };
             })
             .build();

--- a/examples/filter-level/.enb/make.js
+++ b/examples/filter-level/.enb/make.js
@@ -16,7 +16,8 @@ module.exports = function (config) {
 
                     return {
                         sourcePath: file.fullname,
-                        targetPath: path.join(dstpath, nestedPath, file.name)
+                        targetPath: path.join(dstpath, nestedPath, file.name),
+                        isDirectory: file.isDirectory
                     };
                 }
             })

--- a/examples/merge-level/.enb/make.js
+++ b/examples/merge-level/.enb/make.js
@@ -27,7 +27,8 @@ module.exports = function (config) {
 
                 return {
                     sourcePath: file.fullname,
-                    targetPath: path.join(dstpath, nestedPath, fileName)
+                    targetPath: path.join(dstpath, nestedPath, fileName),
+                    isDirectory: file.isDirectory
                 };
             })
             .build()

--- a/lib/pseudo-level-builder.js
+++ b/lib/pseudo-level-builder.js
@@ -3,7 +3,7 @@ var path = require('path'),
     vow = require('vow'),
     vfs = require('enb/lib/fs/async-fs');
 
-function symlink(sourcePath, targetPath) {
+function symlink(source, targetPath) {
     var dir = path.dirname(targetPath);
 
     return vfs.makeDir(dir)
@@ -15,9 +15,9 @@ function symlink(sourcePath, targetPath) {
                 return;
             }
 
-            var relativeSourcePath = path.relative(path.dirname(targetPath), sourcePath);
+            var relativeSourcePath = path.relative(path.dirname(targetPath), source.sourcePath);
 
-            return vfs.symLink(relativeSourcePath, targetPath);
+            return vfs.symLink(relativeSourcePath, targetPath, source.isDirectory ? 'dir' : 'file');
         });
 }
 
@@ -32,7 +32,7 @@ function build(dstpath, files, levels, resolve, args) {
         if (solutions) {
             if (!util.isArray(solutions)) {
                 if (typeof solutions === 'string') {
-                    solutions = [{ sourcePath: file.fullname, targetPath: solutions }];
+                    solutions = [{ sourcePath: file.fullname, targetPath: solutions, isDirectory: file.isDirectory }];
                 } else {
                     solutions = [solutions];
                 }
@@ -41,7 +41,7 @@ function build(dstpath, files, levels, resolve, args) {
             solutions.forEach(function (solution) {
                 var targetPath = path.resolve(dstpath, solution.targetPath);
 
-                hash[targetPath] = solution.sourcePath;
+                hash[targetPath] = { sourcePath: solution.sourcePath, isDirectory: solution.isDirectory };
             });
         }
     });
@@ -53,15 +53,16 @@ function build(dstpath, files, levels, resolve, args) {
             arg = arg.replace(/\/$/, '');
 
             targets.forEach(function (target) {
-                var splitedArg = arg.split(path.sep),
-                    splitedTarget = target.split(path.sep);
+                var targetSourcePath = target.sourcePath,
+                    splitedArg = arg.split(path.sep),
+                    splitedTarget = targetSourcePath.split(path.sep);
 
-                if ((splitedArg.length === splitedTarget.length && target === arg) ||
+                if ((splitedArg.length === splitedTarget.length && targetSourcePath === arg) ||
                     ((splitedArg.length < splitedTarget.length) &&
                         (arg === splitedTarget.splice(0, splitedArg.length).join(path.sep))
                     ) ||
                     ((splitedArg.length > splitedTarget.length) &&
-                        (target === splitedArg.splice(0, splitedTarget.length).join(path.sep))
+                        (targetSourcePath === splitedArg.splice(0, splitedTarget.length).join(path.sep))
                     )
                 ) {
                     toSymlink.push(target);


### PR DESCRIPTION
Если создавать симлинки c опциями по умолчанию, то есть 

``` js
fs.symlink(source, target)
```

то на Windows OS `папки` будут всегда создаваться файлами-симлинками. (так как по умолчанию третьим аргументом функции стоит 'files'). На 'нормальных системах' этой проблемы нет и поэтому указываться явно

``` js
fs.symlink(source, target, 'dir' || 'file')
```

 не надо (нужный аргумент подберется сам), но если указать, то это ничего,  конечно же, не сломает для Unix, но починит для Windows OS ;)
